### PR TITLE
API-835: Fix the failing tests workflow on github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,9 +25,17 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-      - name: Run tests
-        run: |
-          make test
+          pip install coverage
+          pip install coveralls
+                 
+      - name: Run tests	      
+        run: |	       
+          make test	       
+      - name: Coverage	   
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        run: |	      
+         coveralls --service=github
 
   deploy:
     name: Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ 3.5, 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
                  
       - name: Run tests	      
         run: |	       
-          make test	       
+          make unittest
       - name: Coverage	   
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ 3.5, 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ 3.5.x, 3.6.x, 3.7, 3.8, 3.9 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           make test
       - name: Coverage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          coverage run --source=mypkg -m pytest tests/
-          coveralls   
+          coveralls

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ 3.5.x, 3.6.x, 3.7, 3.8, 3.9 ]
+        python-version: [ 3.5.10, 3.6.10, 3.7, 3.8, 3.9 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,7 +28,9 @@ jobs:
       - name: Run tests	      
         run: |	       
           make test	       
-      - name: Coverage	      
+      - name: Coverage	   
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   
         run: |	      
          coverage run --source=mypkg -m pytest test/
          coveralls   

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,11 +25,10 @@ jobs:
           pip install coverage
           pip install coveralls
                  
-      - name: Run tests
-        run: |
-          make test
-      - name: Coverage
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          coveralls
+      - name: Run tests	      
+        run: |	       
+          make test	       
+      - name: Coverage	      
+        run: |	      
+         coverage run --source=mypkg -m pytest test/
+         coveralls   

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,6 +31,5 @@ jobs:
       - name: Coverage	   
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-          COVERALLS_SERVICE_NAME: github-actions  
         run: |	      
-         coveralls   
+         coveralls --service=github

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ 3.5.10, 3.6.10, 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install coverage
+
       - name: Run tests
         run: |
           make test
+      - name: coverage
+        run: |
+          coverage.py run -m unittest discover

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,5 +33,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
           COVERALLS_SERVICE_NAME: github-actions  
         run: |	      
-         coverage run --source=mypkg -m pytest --cov test/
          coveralls   

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
                  
       - name: Run tests	      
         run: |	       
-          make test	       
+          make unittest
       - name: Coverage	   
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,5 +33,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
           COVERALLS_SERVICE_NAME: github-actions  
         run: |	      
-         coverage run --source=mypkg -m pytest test/
+         coverage run --source=mypkg -m pytest --cov test/
          coveralls   

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,7 +30,8 @@ jobs:
           make test	       
       - name: Coverage	   
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          COVERALLS_SERVICE_NAME: github-actions  
         run: |	      
          coverage run --source=mypkg -m pytest test/
          coveralls   

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,10 +23,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install coverage
-
+          pip install coveralls
+                 
       - name: Run tests
         run: |
           make test
-      - name: coverage
+      - name: Coverage
         run: |
-          coverage.py run -m unittest discover
+          coverage run --source=mypkg -m pytest tests/
+          coveralls   

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Bynder Python SDK
 
 ![Tests](https://github.com/Bynder/bynder-python-sdk/workflows/Tests/badge.svg)
 ![Publish](https://github.com/Bynder/bynder-python-sdk/workflows/Publish/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/github/Bynder/bynder-python-sdk/badge.svg?branch=master)](https://coveralls.io/github/Bynder/bynder-python-sdk?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/Bynder/bynder-python-sdk/badge.svg)](https://coveralls.io/github/Bynder/bynder-python-sdk)
 
 The main goal of this SDK is to speed up the integration of Bynder
 customers who use Python. Making it easier to connect to the Bynder API

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Bynder Python SDK
 
 ![Tests](https://github.com/Bynder/bynder-python-sdk/workflows/Tests/badge.svg)
 ![Publish](https://github.com/Bynder/bynder-python-sdk/workflows/Publish/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/Arpit-Sharma-USC/bynder-python-sdk/badge.svg?branch=master)](https://coveralls.io/github/Arpit-Sharma-USC/bynder-python-sdk?branch=master)
 
 The main goal of this SDK is to speed up the integration of Bynder
 customers who use Python. Making it easier to connect to the Bynder API

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Bynder Python SDK
 
 ![Tests](https://github.com/Bynder/bynder-python-sdk/workflows/Tests/badge.svg)
 ![Publish](https://github.com/Bynder/bynder-python-sdk/workflows/Publish/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/github/Bynder/bynder-python-sdk/badge.svg)](https://coveralls.io/github/Bynder/bynder-python-sdk)
+[![Coverage Status](https://coveralls.io/repos/github/Bynder/bynder-python-sdk/badge.svg?branch=master)](https://coveralls.io/github/Bynder/bynder-python-sdk?branch=master)
 
 The main goal of this SDK is to speed up the integration of Bynder
 customers who use Python. Making it easier to connect to the Bynder API

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Bynder Python SDK
 ![Tests](https://github.com/Bynder/bynder-python-sdk/workflows/Tests/badge.svg)
 ![Publish](https://github.com/Bynder/bynder-python-sdk/workflows/Publish/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/Bynder/bynder-python-sdk/badge.svg?branch=master)](https://coveralls.io/github/Bynder/bynder-python-sdk?branch=master)
+![PyPI](https://img.shields.io/pypi/v/bynder-sdk)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/bynder-sdk?color=orange)
 
 The main goal of this SDK is to speed up the integration of Bynder
 customers who use Python. Making it easier to connect to the Bynder API

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Bynder Python SDK
 
 ![Tests](https://github.com/Bynder/bynder-python-sdk/workflows/Tests/badge.svg)
 ![Publish](https://github.com/Bynder/bynder-python-sdk/workflows/Publish/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/github/Arpit-Sharma-USC/bynder-python-sdk/badge.svg?branch=master)](https://coveralls.io/github/Arpit-Sharma-USC/bynder-python-sdk?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/Bynder/bynder-python-sdk/badge.svg?branch=master)](https://coveralls.io/github/Bynder/bynder-python-sdk?branch=master)
 
 The main goal of this SDK is to speed up the integration of Bynder
 customers who use Python. Making it easier to connect to the Bynder API

--- a/bynder_sdk/client/asset_bank_client.py
+++ b/bynder_sdk/client/asset_bank_client.py
@@ -33,7 +33,7 @@ class AssetBankClient:
         """ Gets all the media information for a specific media id.
         """
         return self.session.get(
-            '/v4/media/{0}/'.format(media_id),
+            f'/v4/media/{media_id}/',
             params=versions or {}
         )
 
@@ -41,7 +41,7 @@ class AssetBankClient:
         """ Gets the download file URL for a specific media id.
         """
         return self.session.get(
-            '/v4/media/{0}/download/'.format(media_id),
+            f'/v4/media/{media_id}/download/',
             params=query or {}
         )
 
@@ -49,14 +49,14 @@ class AssetBankClient:
         """ Updates the media properties (metadata) for a specific media id.
         """
         return self.session.post(
-            '/v4/media/{0}/'.format(media_id),
+            f'/v4/media/{media_id}/',
             data=query or {}
         )
 
     def delete_media(self, media_id):
         """ Deletes a media asset.
         """
-        return self.session.delete('/v4/media/{0}/'.format(media_id))
+        return self.session.delete(f'/v4/media/{media_id}/')
 
     def create_usage(self, integration_id, asset_id, query: dict = None):
         """ Creates a usage record for a media asset.

--- a/bynder_sdk/client/bynder_client.py
+++ b/bynder_sdk/client/bynder_client.py
@@ -1,11 +1,9 @@
-
 from bynder_sdk.client.asset_bank_client import AssetBankClient
 from bynder_sdk.client.collection_client import CollectionClient
 from bynder_sdk.client.pim_client import PIMClient
 from bynder_sdk.client.workflow_client import WorkflowClient
 from bynder_sdk.oauth2 import BynderOAuth2Session
 from bynder_sdk.permanent_token import PermanentTokenSession
-
 
 REQUIRED_OAUTH_KWARGS = (
     'client_id', 'client_secret', 'redirect_uri', 'scopes')
@@ -62,6 +60,7 @@ class BynderClient:
         )
 
     def derivatives(self):
-        """ Gets the list of the derivatives configured for the current account.
+        """ Gets the list of the derivatives configured for the current
+        account.
         """
         return self.session.get('/v4/account/derivatives/')

--- a/bynder_sdk/client/bynder_client.py
+++ b/bynder_sdk/client/bynder_client.py
@@ -26,7 +26,7 @@ class BynderClient:
             ]
             if missing:
                 raise TypeError(
-                    'Missing required arguments: {}'.format(missing)
+                    f'Missing required arguments: {missing}'
                 )
 
             self.session = BynderOAuth2Session(

--- a/bynder_sdk/client/collection_client.py
+++ b/bynder_sdk/client/collection_client.py
@@ -15,7 +15,7 @@ class CollectionClient:
     def collection_info(self, collection_id):
         """ Gets all the collection information for a specific collection id.
         """
-        return self.session.get('/v4/collections/{0}/'.format(collection_id))
+        return self.session.get(f'/v4/collections/{collection_id}/')
 
     def create_collection(self, name, query: dict = None):
         """ Creates a collection.
@@ -29,14 +29,14 @@ class CollectionClient:
         """ Deletes a collection.
         """
         return self.session.delete(
-            '/v4/collections/{0}/'.format(collection_id)
+            f'/v4/collections/{collection_id}/'
         )
 
     def collection_media_ids(self, collection_id):
         """ Gets a list of the media assets ids of a collection.
         """
         return self.session.get(
-            '/v4/collections/{0}/media/'.format(collection_id)
+            f'/v4/collections/{collection_id}/media/'
         )
 
     def add_media_to_collection(self, collection_id, media_ids: list):
@@ -46,7 +46,7 @@ class CollectionClient:
             'data': json.dumps(media_ids)
         }
         return self.session.post(
-            '/v4/collections/{0}/media/'.format(collection_id),
+            f'/v4/collections/{collection_id}/media/',
             data=query
         )
 
@@ -57,7 +57,7 @@ class CollectionClient:
             'deleteIds': ','.join(map(str, media_ids))
         }
         return self.session.delete(
-            '/v4/collections/{0}/media/'.format(collection_id),
+            f'/v4/collections/{collection_id}/media/',
             params=query
         )
 
@@ -68,14 +68,14 @@ class CollectionClient:
         collection_options = ['view', 'edit']
         if collection_option not in collection_options:
             raise ValueError(
-                'Invalid collection_option. Expected one of: {0}'.format(
-                    collection_options)
+                f'Invalid collection_option. Expected one of: '
+                f'{collection_options}'
             )
         if query is None:
             query = {}
         query['collectionOptions'] = collection_option
         query['recipients'] = ','.join(map(str, recipients))
         return self.session.post(
-            '/v4/collections/{0}/share/'.format(collection_id),
+            f'/v4/collections/{collection_id}/share/',
             data=query
         )

--- a/bynder_sdk/client/pim_client.py
+++ b/bynder_sdk/client/pim_client.py
@@ -13,15 +13,14 @@ class PIMClient:
         """ Get metaproperty info about a specific metaproperty.
         """
         return self.session.get(
-            '/pim/metaproperties/{}/'.format(metaproperty_id)
+            f'/pim/metaproperties/{metaproperty_id}/'
         )
 
     def metaproperty_options(self, metaproperty_id, query: dict = None):
         """ Get list of metaproperty options.
         """
         return self.session.get(
-            '/pim/metaproperties/{}/options/'.format(
-                metaproperty_id),
+            f'/pim/metaproperties/{metaproperty_id}/options/',
             params=query or {}
         )
 
@@ -31,7 +30,6 @@ class PIMClient:
         if isinstance(children, str):
             children = [children]
         return self.session.put(
-            '/pim/metapropertyoptions/{}/'.format(
-                metaproperty_option_id),
+            f'/pim/metapropertyoptions/{metaproperty_option_id}/',
             json={'children': children}
         )

--- a/bynder_sdk/client/upload_client.py
+++ b/bynder_sdk/client/upload_client.py
@@ -67,7 +67,7 @@ class UploadClient():
             'name': filename,
         })
 
-        key = '{}/p{{}}'.format(data['s3_filename'])
+        key = f'{data["s3_filename"]}/p{{}}'
 
         def part_data(part_nr):
             data['s3_filename'] = key.format(part_nr)
@@ -97,7 +97,7 @@ class UploadClient():
         """ Finalises a completely uploaded file.
         """
         return self.session.post(
-            '/v4/upload/{0}/'.format(init_data['s3file']['uploadid']),
+            f'/v4/upload/{init_data["s3file"]["uploadid"]}/',
             data={
                 'id': init_data['s3file']['uploadid'],
                 'targetid': init_data['s3file']['targetid'],
@@ -115,10 +115,9 @@ class UploadClient():
         if import_id not in poll_status['itemsDone']:
             raise Exception('Converting media failed')
 
-        save_endpoint = '/v4/media/save/{}/'.format(import_id)
+        save_endpoint = f'/v4/media/save/{import_id}/'
         if media_id:
-            save_endpoint = '/v4/media/{}/save/{}/'.format(
-                media_id, import_id)
+            save_endpoint = f'/v4/media/{media_id}/save/{import_id}/'
             data = {}
 
         return self.session.post(

--- a/bynder_sdk/client/workflow_client.py
+++ b/bynder_sdk/client/workflow_client.py
@@ -20,7 +20,7 @@ class WorkflowClient:
         """ Gets all the campaign information for a specific campaign id.
         """
         return self.session.get(
-            '/workflow/campaigns/{0}/'.format(campaign_id)
+            f'/workflow/campaigns/{campaign_id}/'
         )
 
     # pylint: disable=too-many-arguments
@@ -42,7 +42,7 @@ class WorkflowClient:
         """ Deletes a campaign.
         """
         return self.session.delete(
-            '/workflow/campaigns/{0}/'.format(campaign_id)
+            f'/workflow/campaigns/{campaign_id}/'
         )
 
     def edit_campaign(self, campaign_id, name, key, description,
@@ -58,7 +58,7 @@ class WorkflowClient:
             'responsibleID': responsible_id
         })
         return self.session.put(
-            '/workflow/campaigns/{0}/'.format(campaign_id),
+            f'/workflow/campaigns/{campaign_id}/',
             json=query
         )
 
@@ -67,24 +67,24 @@ class WorkflowClient:
 
     def metaproperty_info(self, metaproperty_id):
         return self.session.get(
-            '/workflow/metaproperties/{}/'.format(metaproperty_id)
+            f'/workflow/metaproperties/{metaproperty_id}/'
         )
 
     def groups(self):
         return self.session.get('/workflow/groups/')
 
     def group_info(self, group_id):
-        return self.session.get('/workflow/groups/{}/'.format(group_id))
+        return self.session.get(f'/workflow/groups/{group_id}/')
 
     def job_preset_info(self, job_preset_id):
         return self.session.get(
-            '/workflow/presets/job/{}/'.format(job_preset_id)
+            f'/workflow/presets/job/{job_preset_id}/'
         )
 
     def jobs(self, campaign_id: str = None):
         if campaign_id:
             return self.session.get(
-                '/workflow/campaigns/{}/jobs/'.format(campaign_id)
+                f'/workflow/campaigns/{campaign_id}/jobs/'
             )
         return self.session.get('/workflow/jobs/')
 
@@ -101,7 +101,7 @@ class WorkflowClient:
         return self.session.post('/workflow/jobs/', json=query)
 
     def job_info(self, job_id):
-        return self.session.get('/workflow/jobs/{}/'.format(job_id))
+        return self.session.get(f'/workflow/jobs/{job_id}/')
 
     def edit_job(self, job_id, name, campaign_id, accountable_id,
                  preset_id, query: dict = None):
@@ -114,9 +114,9 @@ class WorkflowClient:
             'presetID': preset_id
         })
         return self.session.put(
-            '/workflow/jobs/{}/'.format(job_id),
+            f'/workflow/jobs/{job_id}/',
             json=query
         )
 
     def delete_job(self, job_id):
-        return self.session.delete('/workflow/jobs/{}/'.format(job_id))
+        return self.session.delete(f'/workflow/jobs/{job_id}/')

--- a/bynder_sdk/client/workflow_client.py
+++ b/bynder_sdk/client/workflow_client.py
@@ -1,6 +1,8 @@
 class WorkflowClient:
-    """ Client used for all the operations that can be done to the workflow module.
+    """ Client used for all the operations that can be done to the workflow
+    module.
     """
+
     def __init__(self, session):
         self.session = session
 

--- a/bynder_sdk/oauth2.py
+++ b/bynder_sdk/oauth2.py
@@ -7,8 +7,7 @@ from bynder_sdk.util import SessionMixin
 
 
 def oauth2_url(bynder_domain, endpoint):
-    return 'https://{}/v6/authentication/oauth2/{}'.format(
-        bynder_domain, endpoint)
+    return f'https://{bynder_domain}/v6/authentication/oauth2/{endpoint}'
 
 
 class BynderOAuth2Session(SessionMixin, OAuth2Session):

--- a/bynder_sdk/permanent_token.py
+++ b/bynder_sdk/permanent_token.py
@@ -9,7 +9,7 @@ class PermanentTokenSession(SessionMixin, Session):
 
         self.bynder_domain = bynder_domain
         self.headers.update({
-            'Authorization': 'Bearer {}'.format(permanent_token),
+            'Authorization': f'Bearer {permanent_token}',
         })
 
         self._set_ua_header()

--- a/bynder_sdk/util.py
+++ b/bynder_sdk/util.py
@@ -1,12 +1,12 @@
 from bynder_sdk.version import VERSION
 
 UA_HEADER = {
-    'User-Agent': 'bynder-python-sdk/{}'.format(VERSION)
+    'User-Agent': f'bynder-python-sdk/{VERSION}'
 }
 
 
 def api_endpoint_url(session, endpoint):
-    return 'https://{}/api{}'.format(session.bynder_domain, endpoint)
+    return f'https://{session.bynder_domain}/api{endpoint}'
 
 
 def parse_json_for_response(response):

--- a/test/asset_bank_client_test.py
+++ b/test/asset_bank_client_test.py
@@ -167,10 +167,7 @@ class AssetBankClientTest(TestCase):
             asset_id=payload['asset_id']
         )
         self.asset_bank_client.session \
-            .delete.assert_called_with(
-            '/media/usage/',
-            params=payload
-        )
+            .delete.assert_called_with('/media/usage/', params=payload)
 
     def test_upload_file(self):
         """ Test if when we call upload_file it will use the correct params

--- a/test/asset_bank_client_test.py
+++ b/test/asset_bank_client_test.py
@@ -6,6 +6,7 @@ from test import create_bynder_client
 class AssetBankClientTest(TestCase):
     """ Test the Asset Bank client.
     """
+
     def setUp(self):
         self.bynder_client = create_bynder_client()
 
@@ -49,7 +50,8 @@ class AssetBankClientTest(TestCase):
         )
 
     def test_meta_properties(self):
-        """ Test if when we call meta_properties it will use the correct params for the
+        """ Test if when we call meta_properties it will use the correct
+        params for the
         request and returns successfully.
         """
         self.asset_bank_client.meta_properties()
@@ -59,7 +61,8 @@ class AssetBankClientTest(TestCase):
         )
 
     def test_media_list(self):
-        """ Test if when we call media_list it will use the correct params for the
+        """ Test if when we call media_list it will use the correct params
+        for the
         request and returns successfully.
         """
         self.asset_bank_client.media_list()
@@ -82,7 +85,8 @@ class AssetBankClientTest(TestCase):
         )
 
     def test_media_info(self):
-        """ Test if when we call media_info it will use the correct params for the
+        """ Test if when we call media_info it will use the correct params
+        for the
         request and returns successfully.
         """
         self.asset_bank_client.media_info(media_id=1111)
@@ -92,7 +96,8 @@ class AssetBankClientTest(TestCase):
         )
 
     def test_download_url(self):
-        """ Test if when we call download_url it will use the correct params for the
+        """ Test if when we call download_url it will use the correct params
+        for the
         request and returns successfully.
         """
         self.asset_bank_client.media_download_url(media_id=1111)
@@ -112,15 +117,17 @@ class AssetBankClientTest(TestCase):
         )
 
     def test_delete_media(self):
-        """ Test if when we call delete_media it will use the correct params for the
+        """ Test if when we call delete_media it will use the correct params
+        for the
         request and returns successfully.
         """
         self.asset_bank_client.delete_media(media_id=1111)
-        self.asset_bank_client.session\
+        self.asset_bank_client.session \
             .delete.assert_called_with('/v4/media/1111/')
 
     def test_create_usage(self):
-        """ Test if when we call create_usage it will use the correct params for the
+        """ Test if when we call create_usage it will use the correct params
+        for the
         request and returns successfully.
         """
         payload = {
@@ -137,7 +144,8 @@ class AssetBankClientTest(TestCase):
         )
 
     def test_get_usage(self):
-        """ Test if when we call get_usage it will use the correct params for the
+        """ Test if when we call get_usage it will use the correct params
+        for the
         request and returns successfully.
         """
         self.asset_bank_client.usage()
@@ -146,7 +154,8 @@ class AssetBankClientTest(TestCase):
         )
 
     def test_delete_usage(self):
-        """ Test if when we call delete_usage it will use the correct params for the
+        """ Test if when we call delete_usage it will use the correct params
+        for the
         request and returns successfully.
         """
         payload = {
@@ -157,14 +166,15 @@ class AssetBankClientTest(TestCase):
             integration_id=payload['integration_id'],
             asset_id=payload['asset_id']
         )
-        self.asset_bank_client.session\
+        self.asset_bank_client.session \
             .delete.assert_called_with(
-                '/media/usage/',
-                params=payload
-            )
+            '/media/usage/',
+            params=payload
+        )
 
     def test_upload_file(self):
-        """ Test if when we call upload_file it will use the correct params for the
+        """ Test if when we call upload_file it will use the correct params
+        for the
         requests.
         """
         file_path = 'path_to_a_file.png'

--- a/test/collection_client_test.py
+++ b/test/collection_client_test.py
@@ -93,10 +93,10 @@ class CollectionClientTest(TestCase):
         self.collection_client.remove_media_from_collection(
             collection_id=1111, media_ids=media_ids)
         self.collection_client.session \
-            .delete.assert_called_with(
-            '/v4/collections/1111/media/',
-            params={'deleteIds': ','.join(map(str, media_ids))}
-        )
+            .delete \
+            .assert_called_with('/v4/collections/1111/media/',
+                                params={'deleteIds': ','.join(map(str,
+                                                                  media_ids))})
 
     def test_share_collection(self):
         """ Test if when we call share collection it will use the correct

--- a/test/collection_client_test.py
+++ b/test/collection_client_test.py
@@ -7,6 +7,7 @@ from test import create_bynder_client
 class CollectionClientTest(TestCase):
     """ Test the collection client.
     """
+
     def setUp(self):
         self.bynder_client = create_bynder_client()
 
@@ -20,7 +21,8 @@ class CollectionClientTest(TestCase):
         self.collection_client = None
 
     def test_collections(self):
-        """ Test if when we call collections it will use the correct params for the
+        """ Test if when we call collections it will use the correct params
+        for the
         request and returns successfully.
         """
         self.collection_client.collections()
@@ -30,7 +32,8 @@ class CollectionClientTest(TestCase):
         )
 
     def test_collection_info(self):
-        """ Test if when we call collection info it will use the correct params for the
+        """ Test if when we call collection info it will use the correct
+        params for the
         request and returns successfully.
         """
         self.collection_client.collection_info(collection_id=1111)
@@ -56,7 +59,7 @@ class CollectionClientTest(TestCase):
         params for the request and returns successfully.
         """
         self.collection_client.delete_collection(collection_id=1111)
-        self.collection_client.session.delete\
+        self.collection_client.session.delete \
             .assert_called_with('/v4/collections/1111/')
 
     def test_collection_media_ids(self):
@@ -69,7 +72,8 @@ class CollectionClientTest(TestCase):
         )
 
     def test_add_media_to_collection(self):
-        """ Test if when we call add media to collection it will use the correct
+        """ Test if when we call add media to collection it will use the
+        correct
         params for the request and returns successfully.
         """
         media_ids = ['2222', '3333']
@@ -81,17 +85,18 @@ class CollectionClientTest(TestCase):
         )
 
     def test_remove_media_from_collection(self):
-        """ Test if when we call remove media from collection it will use the correct
+        """ Test if when we call remove media from collection it will use
+        the correct
         params for the request and returns successfully.
         """
         media_ids = ['2222', '3333']
         self.collection_client.remove_media_from_collection(
             collection_id=1111, media_ids=media_ids)
-        self.collection_client.session\
+        self.collection_client.session \
             .delete.assert_called_with(
-                '/v4/collections/1111/media/',
-                params={'deleteIds': ','.join(map(str, media_ids))}
-            )
+            '/v4/collections/1111/media/',
+            params={'deleteIds': ','.join(map(str, media_ids))}
+        )
 
     def test_share_collection(self):
         """ Test if when we call share collection it will use the correct

--- a/test/oauth2_session_test.py
+++ b/test/oauth2_session_test.py
@@ -22,13 +22,13 @@ class OAuth2Test(TestCase):
     def test_oauth2_url(self):
         self.assertEqual(
             oauth2_url(TEST_DOMAIN, 'token'),
-            'https://{}/v6/authentication/oauth2/token'.format(TEST_DOMAIN),
+            f'https://{TEST_DOMAIN}/v6/authentication/oauth2/token',
         )
 
     def test_api_endpoint_url(self):
         self.assertEqual(
             api_endpoint_url(self.session, '/v4/users/'),
-            'https://{}/api/v4/users/'.format(TEST_DOMAIN)
+            f'https://{TEST_DOMAIN}/api/v4/users/'
         )
 
     @mock.patch('requests_oauthlib.OAuth2Session.authorization_url')

--- a/test/pim_client_test.py
+++ b/test/pim_client_test.py
@@ -6,6 +6,7 @@ from test import create_bynder_client
 class PIMClientTest(TestCase):
     """ Test the PIM client.
     """
+
     def setUp(self):
         self.bynder_client = create_bynder_client()
 
@@ -18,7 +19,8 @@ class PIMClientTest(TestCase):
         self.pim_client = None
 
     def test_metaproperties(self):
-        """ Test if when we call metaproperties it will use the correct params for
+        """ Test if when we call metaproperties it will use the correct
+        params for
         the request and returns successfully.
         """
         self.pim_client.metaproperties()
@@ -27,7 +29,8 @@ class PIMClientTest(TestCase):
         )
 
     def test_metaproperty_info(self):
-        """ Test if when we call metaproperty info it will use the correct params
+        """ Test if when we call metaproperty info it will use the correct
+        params
         for the request and returns successfully.
         """
         self.pim_client.metaproperty_info(metaproperty_id=1111)
@@ -36,7 +39,8 @@ class PIMClientTest(TestCase):
         )
 
     def test_metaproperty_options(self):
-        """ Test if when we call meteproperty options it will use the correct params
+        """ Test if when we call meteproperty options it will use the
+        correct params
         for the request and returns successfully.
         """
         self.pim_client.metaproperty_options(metaproperty_id=1111)
@@ -45,7 +49,8 @@ class PIMClientTest(TestCase):
         )
 
     def test_edit_metaproperty_option(self):
-        """ Test if when we call edit metaproperty option it will use the correct
+        """ Test if when we call edit metaproperty option it will use the
+        correct
         params for the request and returns successfully.
         """
         self.pim_client.edit_metaproperty_option(

--- a/test/pim_client_test.py
+++ b/test/pim_client_test.py
@@ -35,7 +35,7 @@ class PIMClientTest(TestCase):
         """
         self.pim_client.metaproperty_info(metaproperty_id=1111)
         self.pim_client.session.get(
-            '/pim/metaproperties/{}/'.format(1111)
+            f'/pim/metaproperties/{1111}/'
         )
 
     def test_metaproperty_options(self):
@@ -45,7 +45,7 @@ class PIMClientTest(TestCase):
         """
         self.pim_client.metaproperty_options(metaproperty_id=1111)
         self.pim_client.session.get(
-            '/pim/metaproperties/{}/options/'.format(1111)
+            f'/pim/metaproperties/{1111}/options/'
         )
 
     def test_edit_metaproperty_option(self):
@@ -58,7 +58,7 @@ class PIMClientTest(TestCase):
             children=['2222', '3333']
         )
         self.pim_client.session.put.assert_called_with(
-            '/pim/metapropertyoptions/{}/'.format(1111),
+            f'/pim/metapropertyoptions/{1111}/',
             json={'children': ['2222', '3333']}
         )
 
@@ -67,6 +67,6 @@ class PIMClientTest(TestCase):
             children='2222'
         )
         self.pim_client.session.put.assert_called_with(
-            '/pim/metapropertyoptions/{}/'.format(1111),
+            f'/pim/metapropertyoptions/{1111}/',
             json={'children': ['2222']}
         )

--- a/test/workflow_client_test.py
+++ b/test/workflow_client_test.py
@@ -6,6 +6,7 @@ from test import create_bynder_client
 class WorkflowClientTest(TestCase):
     """ Test the workflow client.
     """
+
     def setUp(self):
         self.bynder_client = create_bynder_client()
 
@@ -20,7 +21,8 @@ class WorkflowClientTest(TestCase):
         self.workflow_client = None
 
     def test_users(self):
-        """ Test if when we call workflow users it will use the correct params for
+        """ Test if when we call workflow users it will use the correct
+        params for
         the request and returns successfully.
         """
         self.workflow_client.users()
@@ -29,7 +31,8 @@ class WorkflowClientTest(TestCase):
         )
 
     def test_campaigns(self):
-        """ Test if when we call campaigns it will use the correct params for the
+        """ Test if when we call campaigns it will use the correct params
+        for the
         request and returns successfully.
         """
         self.workflow_client.campaigns()
@@ -39,7 +42,8 @@ class WorkflowClientTest(TestCase):
         )
 
     def test_campaign_info(self):
-        """ Test if when we call campaign info it will use the correct params for the
+        """ Test if when we call campaign info it will use the correct
+        params for the
         request and returns successfully.
         """
         self.workflow_client.campaign_info(campaign_id=1111)
@@ -48,7 +52,8 @@ class WorkflowClientTest(TestCase):
         )
 
     def test_create_campaign(self):
-        """ Test if when we call create a campaign it will use the correct params for
+        """ Test if when we call create a campaign it will use the correct
+        params for
         the request and returns successfully.
         """
         self.workflow_client.create_campaign(
@@ -68,7 +73,8 @@ class WorkflowClientTest(TestCase):
         )
 
     def test_edit_campaign(self):
-        """ Test if when we call edit campaign it will use the correct params for
+        """ Test if when we call edit campaign it will use the correct
+        params for
         the request and returns successfully.
         """
         self.workflow_client.edit_campaign(
@@ -89,7 +95,8 @@ class WorkflowClientTest(TestCase):
         )
 
     def test_delete_campaign(self):
-        """ Test if when we call delete campaign it will use the correct params for the
+        """ Test if when we call delete campaign it will use the correct
+        params for the
         request and returns successfully.
         """
         self.workflow_client.delete_campaign(campaign_id=1111)
@@ -98,7 +105,8 @@ class WorkflowClientTest(TestCase):
         )
 
     def test_metaproperties(self):
-        """ Test if when we call metaproperties it will use the correct params for
+        """ Test if when we call metaproperties it will use the correct
+        params for
         the request and returns successfully.
         """
         self.workflow_client.metaproperties()
@@ -107,7 +115,8 @@ class WorkflowClientTest(TestCase):
         )
 
     def test_metaproperty_info(self):
-        """ Test if when we call metaproperty info it will use the correct params
+        """ Test if when we call metaproperty info it will use the correct
+        params
         for the request and returns successfully
         """
         self.workflow_client.metaproperty_info(metaproperty_id=1111)
@@ -125,7 +134,8 @@ class WorkflowClientTest(TestCase):
         )
 
     def test_group_info(self):
-        """ Test if when we call group info it will use the correct params for the
+        """ Test if when we call group info it will use the correct params
+        for the
         request and returns successfully.
         """
         self.workflow_client.group_info(1111)
@@ -134,7 +144,8 @@ class WorkflowClientTest(TestCase):
         )
 
     def test_job_preset_info(self):
-        """ Test if when we call job preset info it will use the correct params for
+        """ Test if when we call job preset info it will use the correct
+        params for
         the request and returns successfully.
         """
         self.workflow_client.job_preset_info(job_preset_id=1111)
@@ -156,7 +167,8 @@ class WorkflowClientTest(TestCase):
         )
 
     def test_create_job(self):
-        """ Test if when we call create job it will use the correct params for the
+        """ Test if when we call create job it will use the correct params
+        for the
         request and returns successfully.
         """
         self.workflow_client.create_job(
@@ -176,7 +188,8 @@ class WorkflowClientTest(TestCase):
         )
 
     def test_job_info(self):
-        """ Test if when we call job info it will use the correct params for the
+        """ Test if when we call job info it will use the correct params for
+        the
         request and returns successfully.
         """
         self.workflow_client.job_info(job_id='1111')
@@ -185,7 +198,8 @@ class WorkflowClientTest(TestCase):
         )
 
     def test_edit_job(self):
-        """ Test if when we call edit job it will use the correct params for the
+        """ Test if when we call edit job it will use the correct params for
+        the
         request and returns successfully.
         """
         self.workflow_client.edit_job(
@@ -206,7 +220,8 @@ class WorkflowClientTest(TestCase):
         )
 
     def test_delete_job(self):
-        """ Test if when we call delete job it will use the correct params for the
+        """ Test if when we call delete job it will use the correct params
+        for the
         request and returns successfully.
         """
         self.workflow_client.delete_job(job_id=1111)

--- a/test/workflow_client_test.py
+++ b/test/workflow_client_test.py
@@ -121,7 +121,7 @@ class WorkflowClientTest(TestCase):
         """
         self.workflow_client.metaproperty_info(metaproperty_id=1111)
         self.workflow_client.session.get.assert_called_with(
-            '/workflow/metaproperties/{}/'.format(1111)
+            f'/workflow/metaproperties/{1111}/'
         )
 
     def test_groups(self):
@@ -140,7 +140,7 @@ class WorkflowClientTest(TestCase):
         """
         self.workflow_client.group_info(1111)
         self.workflow_client.session.get.assert_called_with(
-            '/workflow/groups/{}/'.format(1111)
+            f'/workflow/groups/{1111}/'
         )
 
     def test_job_preset_info(self):
@@ -150,7 +150,7 @@ class WorkflowClientTest(TestCase):
         """
         self.workflow_client.job_preset_info(job_preset_id=1111)
         self.workflow_client.session.get.assert_called_with(
-            '/workflow/presets/job/{}/'.format(1111)
+            f'/workflow/presets/job/{1111}/'
         )
 
     def test_jobs(self):
@@ -159,7 +159,7 @@ class WorkflowClientTest(TestCase):
         """
         self.workflow_client.jobs(campaign_id=1111)
         self.workflow_client.session.get.assert_called_with(
-            '/workflow/campaigns/{}/jobs/'.format(1111)
+            f'/workflow/campaigns/{1111}/jobs/'
         )
         self.workflow_client.jobs()
         self.workflow_client.session.get.assert_called_with(
@@ -194,7 +194,7 @@ class WorkflowClientTest(TestCase):
         """
         self.workflow_client.job_info(job_id='1111')
         self.workflow_client.session.get.assert_called_with(
-            '/workflow/jobs/{}/'.format(1111)
+            f'/workflow/jobs/{1111}/'
         )
 
     def test_edit_job(self):
@@ -210,7 +210,7 @@ class WorkflowClientTest(TestCase):
             preset_id='job_preset_id'
         )
         self.workflow_client.session.put.assert_called_with(
-            '/workflow/jobs/{}/'.format(1111),
+            f'/workflow/jobs/{1111}/',
             json={
                 'name': 'job_name',
                 'campaignID': 'job_campaign_id',
@@ -226,5 +226,5 @@ class WorkflowClientTest(TestCase):
         """
         self.workflow_client.delete_job(job_id=1111)
         self.workflow_client.session.delete(
-            '/workflow/jobs/{}/'.format(1111)
+            f'/workflow/jobs/{1111}/'
         )


### PR DESCRIPTION
This PR:
- removes unsupported python versions who have met EOL 3.5 and 3.6
- fixes formatting and linting errors

[JIRA](https://bynder.atlassian.net/browse/API-835)