### PR TITLE
API-1458 [Python SDK] Upgrade to latest Python version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ '3.9', '3.10', '3.11' ]
 
     steps:
       - uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,7 +2,7 @@
 
 name: Tests
 
-on: [ push, pull_request ]
+on: [ push, pull_request, workflow_dispatch ]
 
 jobs:
   build:
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.9, 3.10, 3.11 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ 3.9, 3.10, 3.11 ]
+        python-version: [ '3.9', '3.10', '3.11' ]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
https://bynder.atlassian.net/browse/API-1458

Updated workflow Python versions, removed `3.7` due to EOL being soon. Added `3.10` and `3.11`. Changes are similar to what was done for https://github.com/Bynder/bynder-python-sdk/pull/35/files.

Using `3.11` for `Publish` job.

Added `workflow_dispatch` to see if we could trigger `Tests` job manually without pushing or creating pull request.
Reference: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow

Python version EOL dates: https://endoflife.date/python
