### PR TITLE
API-2197 [BE] Add client credentials auth support for Python SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,36 @@ bynder_client = BynderClient(
   permanent_token=''
 )
 ```
+To use client credentials grant type, add the field `client_credentials` to `secret.json` and set the field to true. 
+
+```json
+{
+    "domain": "*****",
+    "client_id": "*****",
+    "client_secret": "******",
+    "client_credentials": true,
+    "scopes": ["asset.usage:write", "collection:write", "meta.workflow:read", "asset:write", "asset:read", "meta.assetbank:write", "collection:read", "admin.user:read", "meta.assetbank:read", "current.user:read", "current.profile:read", "offline", "admin.profile:read", "asset.usage:read", "admin.user:write"]
+}
+```
+``` python
+# client credentials grant type
+elif self.config_data.get('token', None) is None and self.config_data.get('client_credentials', None) == True:
+    bynder_client.fetch_token(code=None)
+```
+
+```python
+bynder_client = BynderClient(
+    **self.config_data,
+    token_saver=self.token_saver,  # optional, defaults to empty lambda
+)
+```
+Client credentials provided as keyword argument:
+```python
+bynder_client = BynderClient(
+    client_credentials=True,
+    token_saver=self.token_saver,  # optional, defaults to empty lambda
+)
+```
 
 Finally call one of the API's endpoints through one of the clients:
 

--- a/bynder_sdk/client/bynder_client.py
+++ b/bynder_sdk/client/bynder_client.py
@@ -31,7 +31,7 @@ class BynderClient:
                 )
 
             # if client credentials use BackendApplicationClient from oauthlib, client suited for client credentials
-            client_credentials = BackendApplicationClient(kwargs['client_id']) if kwargs['client_credentials'] else None
+            client_credentials = BackendApplicationClient(kwargs['client_id']) if kwargs.get('client_credentials', None) else None
             self.session = BynderOAuth2Session(
                 domain,
                 kwargs['client_id'],

--- a/bynder_sdk/client/bynder_client.py
+++ b/bynder_sdk/client/bynder_client.py
@@ -31,7 +31,7 @@ class BynderClient:
                 )
 
             # if client credentials use BackendApplicationClient from oauthlib, client suited for client credentials
-            client_credentials = BackendApplicationClient(kwargs['client_id']) if kwargs.get('client_credentials', None) else None
+            client_credentials = BackendApplicationClient(kwargs['client_id']) if kwargs.get('client_credentials', None) == True else None
             self.session = BynderOAuth2Session(
                 domain,
                 kwargs['client_id'],

--- a/bynder_sdk/client/bynder_client.py
+++ b/bynder_sdk/client/bynder_client.py
@@ -4,6 +4,7 @@ from bynder_sdk.client.pim_client import PIMClient
 from bynder_sdk.client.workflow_client import WorkflowClient
 from bynder_sdk.oauth2 import BynderOAuth2Session
 from bynder_sdk.permanent_token import PermanentTokenSession
+from oauthlib.oauth2 import BackendApplicationClient
 
 REQUIRED_OAUTH_KWARGS = (
     'client_id', 'client_secret', 'redirect_uri', 'scopes')
@@ -29,6 +30,8 @@ class BynderClient:
                     f'Missing required arguments: {missing}'
                 )
 
+            # if client credentials use BackendApplicationClient from oauthlib, client suited for client credentials
+            client_credentials = BackendApplicationClient(kwargs['client_id']) if kwargs['client_credentials'] else None
             self.session = BynderOAuth2Session(
                 domain,
                 kwargs['client_id'],
@@ -38,7 +41,9 @@ class BynderClient:
                     'client_id': kwargs['client_id'],
                     'client_secret': kwargs['client_secret']
                 },
-                token_updater=kwargs.get('token_saver', (lambda _: None))
+                token_updater=kwargs.get('token_saver', (lambda _: None)),
+                # if client is None, default to WebApplicationClient which uses authorization_code grant type
+                client=client_credentials
             )
 
             if kwargs.get('token') is not None:

--- a/samples/client.py
+++ b/samples/client.py
@@ -39,10 +39,16 @@ class BynderClientAuthentication:
         #         "scope": ["offline"],
         #         "token_type": "bearer"
         #     }
-        if self.config_data.get('token', None) is None:
+
+        # auth code grant type
+        if self.config_data.get('token', None) is None and self.config_data.get('client_credentials', None) is None:
             print(bynder_client.get_authorization_url())
 
             code = input('Code: ')
             print(bynder_client.fetch_token(code))
+
+        # client credentials grant type
+        elif self.config_data.get('token', None) is None and self.config_data.get('client_credentials', None):
+            bynder_client.fetch_token(code=None)
 
         return bynder_client

--- a/samples/client.py
+++ b/samples/client.py
@@ -41,14 +41,14 @@ class BynderClientAuthentication:
         #     }
 
         # auth code grant type
-        if self.config_data.get('token', None) is None and self.config_data.get('client_credentials', None) is None:
+        if self.config_data.get('token', None) is None and not self.config_data.get('client_credentials', None):
             print(bynder_client.get_authorization_url())
 
             code = input('Code: ')
             print(bynder_client.fetch_token(code))
 
         # client credentials grant type
-        elif self.config_data.get('token', None) is None and self.config_data.get('client_credentials', None):
+        elif self.config_data.get('token', None) is None and self.config_data.get('client_credentials', None) == True:
             bynder_client.fetch_token(code=None)
 
         return bynder_client


### PR DESCRIPTION
https://bynder.atlassian.net/browse/API-2197 

Add check for `client_credentials` in config json indicating when to use client credentials grant type. SDK uses `oauthlib` library for OAuth operations. `BackendApplicationClient` client is used when client credentials found for OAuth client to use corresponding grant type. 