### PR TITLE
PROPS-2540 add backstage yaml and codeownership to integrations

### DIFF
--- a/backstage.yaml
+++ b/backstage.yaml
@@ -1,0 +1,8 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: bynder-python-sdk
+  description: Python SDK for Bynder API
+spec:
+  owner: integrations
+  lifecycle: production


### PR DESCRIPTION
Add Integrations as the code owners as agreed in: 
- Tech Champions Group
- Assigning Assumptions  present here https://docs.google.com/spreadsheets/d/1nH72ggyrgbT2lZhqtbpmD32tA57DlW5t/edit?gid=1567830080#gid=1567830080

This pull request adds a new Backstage component definition for the Bynder Python SDK. It registers the SDK as a component in the Backstage catalog, specifying its owner and lifecycle.

- Backstage integration:
  * Added a `backstage.yaml` file to register the `bynder-python-sdk` as a component, with metadata including its name, description, owner, and lifecycle.
  
