### PR TITLE
Improve OAuth2 session test coverage

### DIFF
--- a/test/oauth2_session_test.py
+++ b/test/oauth2_session_test.py
@@ -31,10 +31,14 @@ class OAuth2Test(TestCase):
             f'https://{TEST_DOMAIN}/api/v4/users/'
         )
 
+    @mock.patch('bynder_sdk.oauth2.random.choice', return_value='a')
     @mock.patch('requests_oauthlib.OAuth2Session.authorization_url')
-    def test_authorization_url(self, mocked_func):
+    def test_authorization_url(self, mocked_auth_url, mocked_choice):
         self.session.authorization_url()
-        assert mocked_func.call_count == 1
+        mocked_auth_url.assert_called_once_with(
+            oauth2_url(TEST_DOMAIN, 'auth'),
+            state='aaaaaaaa'
+        )
 
     @mock.patch('requests_oauthlib.OAuth2Session.fetch_token')
     def test_fetch_token(self, mocked_func):
@@ -49,3 +53,28 @@ class OAuth2Test(TestCase):
     def test_user_agent_header(self):
         # The UA header is contained within the session headers
         assert UA_HEADER.items() <= self.session.headers.items()
+
+    def test_oauth2_url_auth_endpoint(self):
+        self.assertEqual(
+            oauth2_url(TEST_DOMAIN, 'auth'),
+            f'https://{TEST_DOMAIN}/v6/authentication/oauth2/auth',
+        )
+
+    def test_auto_refresh_url_set_on_init(self):
+        self.assertEqual(
+            self.session.auto_refresh_url,
+            oauth2_url(TEST_DOMAIN, 'token'),
+        )
+
+    @mock.patch('bynder_sdk.util.SessionMixin.post')
+    def test_post_https_url_withholds_token(self, mocked_post):
+        self.session.post('https://example.com/api')
+        mocked_post.assert_called_once_with(
+            'https://example.com/api',
+            withhold_token=True,
+        )
+
+    @mock.patch('bynder_sdk.util.SessionMixin.post')
+    def test_post_http_url_does_not_withhold_token(self, mocked_post):
+        self.session.post('http://example.com/api')
+        mocked_post.assert_called_once_with('http://example.com/api')


### PR DESCRIPTION
Hello! This PR is part of a research project on test quality in open-source Python SDKs.

The `test_authorization_url` only checked `call_count`, so I tightened it up to also verify the URL and the generated state. To do that cleanly, I mocked `random.choice` so the state is deterministic. The odds of it ever causing a flaky test are honestly very low, but pinning it makes the assertion possible without adding any uncertainty.

I also added a few tests:

- `auto_refresh_url` is set correctly on init
- `oauth2_url` with the `auth` endpoint
- `post` forwards `withhold_token=True` for HTTPS URLs
- `post` leaves kwargs untouched for non-HTTPS URLs

All existing tests pass. Happy to adjust anything!